### PR TITLE
add MCP server badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 An [model context protocol (MCP)](https://github.com/modelcontextprotocol) server that extracts and transforms webpage content into clean, LLM-optimized Markdown. Returns article title, main content, excerpt, byline and site name. Uses [Mozilla's Readability algorithm](https://github.com/mozilla/readability) to remove ads, navigation, footers and non-essential elements while preserving the core content structure. [More about MCP](https://modelcontextprotocol.io/introduction).
 
+<a href="https://glama.ai/mcp/servers/jdcx8fmajm"><img width="380" height="200" src="https://glama.ai/mcp/servers/jdcx8fmajm/badge" alt="Mozilla Readability Parser Server MCP server" /></a>
+
 ## Features
 - Removes ads, navigation, footers and other non-essential content
 - Converts clean HTML into well-formatted Markdown (also uses Turndown)


### PR DESCRIPTION
This PR adds a badge for the Mozilla Readability Parser MCP Server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/jdcx8fmajm"><img width="380" height="200" src="https://glama.ai/mcp/servers/jdcx8fmajm/badge" alt="Mozilla Readability Parser Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.